### PR TITLE
modify membership quiz as table view 2 questions

### DIFF
--- a/LoveAndHiphop/LoveAndHiphop.xcodeproj/project.pbxproj
+++ b/LoveAndHiphop/LoveAndHiphop.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		ABA1153F1EBBE61700911786 /* FBViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = ABA1153D1EBBE61700911786 /* FBViewController.xib */; };
 		ABD710291EBFA70C00E302B5 /* UserSignupTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD710281EBFA70C00E302B5 /* UserSignupTableViewController.swift */; };
 		ABD7102B1EBFA71B00E302B5 /* User.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ABD7102A1EBFA71B00E302B5 /* User.storyboard */; };
+		ABF686401EC00F3200DC0690 /* Quiz.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ABF6863F1EC00F3200DC0690 /* Quiz.storyboard */; };
+		ABF686421EC0154300DC0690 /* MembershipQuizTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF686411EC0154300DC0690 /* MembershipQuizTableViewController.swift */; };
 		ABF69D7A1EB1BC4C009FDEB9 /* QuizTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF69D791EB1BC4C009FDEB9 /* QuizTableViewController.swift */; };
 /* End PBXBuildFile section */
 
@@ -73,6 +75,8 @@
 		ABA1153D1EBBE61700911786 /* FBViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = FBViewController.xib; sourceTree = "<group>"; };
 		ABD710281EBFA70C00E302B5 /* UserSignupTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserSignupTableViewController.swift; sourceTree = "<group>"; };
 		ABD7102A1EBFA71B00E302B5 /* User.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = User.storyboard; sourceTree = "<group>"; };
+		ABF6863F1EC00F3200DC0690 /* Quiz.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Quiz.storyboard; sourceTree = "<group>"; };
+		ABF686411EC0154300DC0690 /* MembershipQuizTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MembershipQuizTableViewController.swift; sourceTree = "<group>"; };
 		ABF69D791EB1BC4C009FDEB9 /* QuizTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuizTableViewController.swift; sourceTree = "<group>"; };
 		E3D8FF0AB91CA6CAD1D29D0B /* Pods-LoveAndHiphop.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LoveAndHiphop.release.xcconfig"; path = "Pods/Target Support Files/Pods-LoveAndHiphop/Pods-LoveAndHiphop.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -129,6 +133,7 @@
 				ABD7102A1EBFA71B00E302B5 /* User.storyboard */,
 				226A17B21EBAF6C3005ACC83 /* Main.storyboard */,
 				22E946B01EAFF3CB00DCEC74 /* Info.plist */,
+				ABF6863F1EC00F3200DC0690 /* Quiz.storyboard */,
 			);
 			path = LoveAndHiphop;
 			sourceTree = "<group>";
@@ -148,6 +153,7 @@
 				AB8A14CD1EB28C2500F5AF32 /* SubmitQuizViewController.swift */,
 				ABA1153C1EBBE61700911786 /* FBViewController.swift */,
 				221474FC1EC0069D00D2F9F4 /* MatchDetailedViewController.swift */,
+				ABF686411EC0154300DC0690 /* MembershipQuizTableViewController.swift */,
 			);
 			name = "View Controllers";
 			sourceTree = "<group>";
@@ -269,6 +275,7 @@
 				226A17B31EBAF6C3005ACC83 /* Main.storyboard in Resources */,
 				ABD7102B1EBFA71B00E302B5 /* User.storyboard in Resources */,
 				22DBC3101EBD3E48002D0220 /* ChatMessageCell.xib in Resources */,
+				ABF686401EC00F3200DC0690 /* Quiz.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -337,6 +344,7 @@
 				22E946A31EAFF3CB00DCEC74 /* AppDelegate.swift in Sources */,
 				2254761A1EB4773500C0DCF5 /* FashionObject.swift in Sources */,
 				22E946A51EAFF3CB00DCEC74 /* MatchesViewController.swift in Sources */,
+				ABF686421EC0154300DC0690 /* MembershipQuizTableViewController.swift in Sources */,
 				ABD710291EBFA70C00E302B5 /* UserSignupTableViewController.swift in Sources */,
 				226A17AF1EBA5F7B005ACC83 /* MatchCell.swift in Sources */,
 				225476121EB44AE800C0DCF5 /* TopListenerViewController.swift in Sources */,

--- a/LoveAndHiphop/LoveAndHiphop/AppDelegate.swift
+++ b/LoveAndHiphop/LoveAndHiphop/AppDelegate.swift
@@ -29,6 +29,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     PFFacebookUtils.initializeFacebook(applicationLaunchOptions: launchOptions)
     PFUser.enableRevocableSessionInBackground()
     
+    // Currently, loads quiz when user launches app.
+    // Eventually checks for currently logged in user,
+    // or users who have passed the quiz must be peformed first.
+    let storyboard = UIStoryboard(name: "Quiz", bundle: nil)
+    let initialViewController = storyboard.instantiateViewController(withIdentifier: "MembershipQuizTableViewController")
+    
+    self.window?.rootViewController = initialViewController
+    self.window?.makeKeyAndVisible()
+    
     return FBSDKApplicationDelegate.sharedInstance().application(application, didFinishLaunchingWithOptions: launchOptions)
   }
   

--- a/LoveAndHiphop/LoveAndHiphop/Main.storyboard
+++ b/LoveAndHiphop/LoveAndHiphop/Main.storyboard
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="F8o-iz-bF5">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1421" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -30,7 +30,7 @@
                                         <rect key="frame" x="0.0" y="28" width="375" height="159"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="P47-lu-9cX" id="xsA-z4-gHN" customClass="MatchCell" customModule="LoveAndHiphop" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="158.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="342" height="158"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wlC-cc-p4i">
@@ -255,7 +255,7 @@
                                         <rect key="frame" x="0.0" y="28" width="375" height="93"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="aS9-qk-fBR" id="GHE-at-iaJ">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="92.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="92"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -263,7 +263,7 @@
                                         <rect key="frame" x="0.0" y="121" width="375" height="123"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="3zW-LP-W60" id="qJQ-Jl-zk0">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="122.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="122"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -449,7 +449,7 @@
                                         <rect key="frame" x="0.0" y="28" width="375" height="58"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="tfz-AN-phH" id="KIZ-e9-Twf">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="57.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="57"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="songName" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nVV-jf-yl6">
@@ -674,7 +674,7 @@
                                         <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ZxV-Vo-tsB" id="T20-am-HIp">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="User Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TYk-Hk-9uR">
@@ -722,221 +722,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Qx6-7O-Ody" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2413.5999999999999" y="1295.8020989505249"/>
-        </scene>
-        <!--Quiz-->
-        <scene sceneID="ACm-ZS-Smr">
-            <objects>
-                <pageViewController autoresizesArchivedViewToFullSize="NO" modalTransitionStyle="crossDissolve" transitionStyle="scroll" pageSpacing="2" navigationOrientation="horizontal" spineLocation="none" id="F8o-iz-bF5" customClass="QuizPageViewController" customModule="LoveAndHiphop" customModuleProvider="target" sceneMemberID="viewController">
-                    <navigationItem key="navigationItem" title="Quiz" id="tVL-fj-EAq">
-                        <barButtonItem key="backBarButtonItem" title="Cancel" id="FoB-Oy-Hw6"/>
-                    </navigationItem>
-                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
-                </pageViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="sLZ-LK-wi9" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-2674" y="0.0"/>
-        </scene>
-        <!--Quiz Table View Controller-->
-        <scene sceneID="MaA-JO-Yrg">
-            <objects>
-                <tableViewController storyboardIdentifier="QuizTableViewController" id="fkR-ea-Cke" customClass="QuizTableViewController" customModule="LoveAndHiphop" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="KIN-NT-gRi">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <sections>
-                            <tableViewSection id="187-2l-D9s">
-                                <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="85" id="dB9-Bb-Mjq">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="85"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="dB9-Bb-Mjq" id="Ak7-SB-gvS">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="84.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hip Hop History" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ULp-dr-Gw0">
-                                                    <rect key="frame" x="0.0" y="20" width="375" height="56.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="40"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="ULp-dr-Gw0" secondAttribute="trailing" id="3kZ-Z7-leN"/>
-                                                <constraint firstAttribute="bottom" secondItem="ULp-dr-Gw0" secondAttribute="bottom" constant="8" id="Clo-B9-IuC"/>
-                                                <constraint firstItem="ULp-dr-Gw0" firstAttribute="leading" secondItem="Ak7-SB-gvS" secondAttribute="leading" id="DPq-D8-d2M"/>
-                                                <constraint firstItem="ULp-dr-Gw0" firstAttribute="top" secondItem="Ak7-SB-gvS" secondAttribute="top" constant="20" id="HC1-Xz-98A"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="177" id="SWx-cW-uD8">
-                                        <rect key="frame" x="0.0" y="85" width="375" height="177"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="SWx-cW-uD8" id="SkA-gs-4Ah">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="176.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Which of the following artists won a Grammy for Best New Artist?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0mm-R0-wVM">
-                                                    <rect key="frame" x="25" y="47" width="325" height="82.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="23"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="0mm-R0-wVM" firstAttribute="leading" secondItem="SkA-gs-4Ah" secondAttribute="leading" constant="25" id="De4-2Z-4JY"/>
-                                                <constraint firstItem="0mm-R0-wVM" firstAttribute="centerX" secondItem="SkA-gs-4Ah" secondAttribute="centerX" id="Tzj-gb-4M4"/>
-                                                <constraint firstAttribute="trailing" secondItem="0mm-R0-wVM" secondAttribute="trailing" constant="25" id="i64-tS-fbN"/>
-                                                <constraint firstItem="0mm-R0-wVM" firstAttribute="centerY" secondItem="SkA-gs-4Ah" secondAttribute="centerY" id="jLL-Fo-GW4"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                </cells>
-                            </tableViewSection>
-                            <tableViewSection headerTitle="" id="e9e-S8-S3t">
-                                <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="324" id="eS5-3M-yVk">
-                                        <rect key="frame" x="0.0" y="262" width="375" height="324"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="eS5-3M-yVk" id="vuc-75-rAb">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="323.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kqt-Oy-oBR">
-                                                    <rect key="frame" x="166" y="8.5" width="150" height="150"/>
-                                                    <color key="backgroundColor" red="0.7019608021" green="0.7019608021" blue="0.7019608021" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="150" id="2jd-Tj-zib"/>
-                                                        <constraint firstAttribute="width" constant="150" id="gUM-UB-ymw"/>
-                                                    </constraints>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                    <state key="normal" title="Kendrick Lamar">
-                                                        <color key="titleColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
-                                                    </state>
-                                                    <connections>
-                                                        <action selector="onSelectAnswer:" destination="fkR-ea-Cke" eventType="touchUpInside" id="Lgj-Nw-X6p"/>
-                                                    </connections>
-                                                </button>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MOh-me-6aB">
-                                                    <rect key="frame" x="166" y="166.5" width="150" height="150"/>
-                                                    <color key="backgroundColor" red="0.7019608021" green="0.7019608021" blue="0.7019608021" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" constant="150" id="SFK-t9-C3k"/>
-                                                        <constraint firstAttribute="height" constant="150" id="xee-Qc-TBm"/>
-                                                    </constraints>
-                                                    <state key="normal" title="Lauren Hill">
-                                                        <color key="titleColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
-                                                    </state>
-                                                    <connections>
-                                                        <action selector="onSelectAnswer:" destination="fkR-ea-Cke" eventType="touchUpInside" id="iTt-7V-fiS"/>
-                                                    </connections>
-                                                </button>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="e44-dy-qyZ">
-                                                    <rect key="frame" x="8" y="166.5" width="150" height="150"/>
-                                                    <color key="backgroundColor" red="0.7019608021" green="0.7019608021" blue="0.7019608021" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="150" id="0rw-Jb-bHx"/>
-                                                        <constraint firstAttribute="width" constant="150" id="giG-EU-8Eh"/>
-                                                    </constraints>
-                                                    <state key="normal" title="Drake">
-                                                        <color key="titleColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
-                                                    </state>
-                                                    <connections>
-                                                        <action selector="onSelectAnswer:" destination="fkR-ea-Cke" eventType="touchUpInside" id="NDe-2J-Om9"/>
-                                                    </connections>
-                                                </button>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Co9-Xc-wfU">
-                                                    <rect key="frame" x="8" y="8.5" width="150" height="150"/>
-                                                    <color key="backgroundColor" red="0.7019608021" green="0.7019608021" blue="0.7019608021" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="150" id="Gyo-Ul-rga"/>
-                                                        <constraint firstAttribute="width" constant="150" id="HAG-mX-wDI"/>
-                                                    </constraints>
-                                                    <state key="normal" title="JayZ">
-                                                        <color key="titleColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
-                                                    </state>
-                                                    <connections>
-                                                        <action selector="onSelectAnswer:" destination="fkR-ea-Cke" eventType="touchUpInside" id="91H-cw-iek"/>
-                                                    </connections>
-                                                </button>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="MOh-me-6aB" firstAttribute="width" secondItem="e44-dy-qyZ" secondAttribute="width" id="5bI-68-q1r"/>
-                                                <constraint firstItem="e44-dy-qyZ" firstAttribute="top" secondItem="Co9-Xc-wfU" secondAttribute="bottom" constant="8" id="Gto-nT-kmh"/>
-                                                <constraint firstItem="MOh-me-6aB" firstAttribute="leading" secondItem="e44-dy-qyZ" secondAttribute="trailing" constant="8" id="SB5-9h-5N1"/>
-                                                <constraint firstAttribute="trailing" secondItem="MOh-me-6aB" secondAttribute="trailing" constant="8" id="aUj-pH-ydZ"/>
-                                                <constraint firstItem="kqt-Oy-oBR" firstAttribute="width" secondItem="Co9-Xc-wfU" secondAttribute="width" id="cP5-rl-uag"/>
-                                                <constraint firstItem="e44-dy-qyZ" firstAttribute="leading" secondItem="vuc-75-rAb" secondAttribute="leading" constant="8" id="cj2-Ut-7lU"/>
-                                                <constraint firstAttribute="bottom" secondItem="MOh-me-6aB" secondAttribute="bottom" constant="8" id="dHF-dF-eMd"/>
-                                                <constraint firstItem="kqt-Oy-oBR" firstAttribute="top" secondItem="vuc-75-rAb" secondAttribute="top" constant="8" id="dId-dJ-9Pd"/>
-                                                <constraint firstItem="MOh-me-6aB" firstAttribute="height" secondItem="e44-dy-qyZ" secondAttribute="height" id="ffk-8e-yOC"/>
-                                                <constraint firstAttribute="trailing" secondItem="kqt-Oy-oBR" secondAttribute="trailing" constant="8" id="kky-by-CQe"/>
-                                                <constraint firstAttribute="bottom" secondItem="e44-dy-qyZ" secondAttribute="bottom" constant="8" id="osA-Tq-38y"/>
-                                                <constraint firstItem="kqt-Oy-oBR" firstAttribute="height" secondItem="Co9-Xc-wfU" secondAttribute="height" id="p28-dG-yje"/>
-                                                <constraint firstItem="Co9-Xc-wfU" firstAttribute="top" secondItem="vuc-75-rAb" secondAttribute="top" constant="8" id="pPp-Jm-SMa"/>
-                                                <constraint firstItem="MOh-me-6aB" firstAttribute="top" secondItem="kqt-Oy-oBR" secondAttribute="bottom" constant="8" id="rVq-NU-mq1"/>
-                                                <constraint firstItem="kqt-Oy-oBR" firstAttribute="leading" secondItem="Co9-Xc-wfU" secondAttribute="trailing" constant="8" id="waf-BX-gqX"/>
-                                                <constraint firstItem="Co9-Xc-wfU" firstAttribute="leading" secondItem="vuc-75-rAb" secondAttribute="leading" constant="8" id="ytz-F1-bh7"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                </cells>
-                            </tableViewSection>
-                        </sections>
-                        <connections>
-                            <outlet property="dataSource" destination="fkR-ea-Cke" id="wdS-gw-iYe"/>
-                            <outlet property="delegate" destination="fkR-ea-Cke" id="mZ7-hZ-tuC"/>
-                        </connections>
-                    </tableView>
-                    <connections>
-                        <outlet property="answer1Button" destination="Co9-Xc-wfU" id="80B-CB-zed"/>
-                        <outlet property="answer2Button" destination="kqt-Oy-oBR" id="Z2s-VP-eMY"/>
-                        <outlet property="answer3Button" destination="e44-dy-qyZ" id="xWE-5F-bwg"/>
-                        <outlet property="answer4Button" destination="MOh-me-6aB" id="sYD-3R-IAV"/>
-                        <outlet property="categoryLabel" destination="ULp-dr-Gw0" id="Qpb-lx-fcf"/>
-                        <outlet property="questionLabel" destination="0mm-R0-wVM" id="YUL-P9-f9l"/>
-                        <outlet property="tableView" destination="KIN-NT-gRi" id="CK9-hg-CWe"/>
-                    </connections>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="jDo-uv-eqa" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-1994" y="0.0"/>
-        </scene>
-        <!--Submit Quiz View Controller-->
-        <scene sceneID="m3G-K8-b7s">
-            <objects>
-                <viewController storyboardIdentifier="SubmitQuizViewController" id="1Kv-nR-LMO" customClass="SubmitQuizViewController" customModule="LoveAndHiphop" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="kyd-pe-sm0"/>
-                        <viewControllerLayoutGuide type="bottom" id="Gfs-O6-Ok8"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="zQO-qZ-RSs">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OFC-Xk-sa8">
-                                <rect key="frame" x="99.5" y="298.5" width="176" height="70"/>
-                                <color key="backgroundColor" red="0.60000002379999995" green="0.60000002379999995" blue="0.60000002379999995" alpha="1" colorSpace="calibratedRGB"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="25"/>
-                                <inset key="contentEdgeInsets" minX="20" minY="20" maxX="20" maxY="20"/>
-                                <state key="normal" title="Submit Quiz">
-                                    <color key="titleColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <connections>
-                                    <action selector="onSubmit:" destination="1Kv-nR-LMO" eventType="touchUpInside" id="5o8-DW-baP"/>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstItem="OFC-Xk-sa8" firstAttribute="centerY" secondItem="zQO-qZ-RSs" secondAttribute="centerY" id="BB7-Dy-6uj"/>
-                            <constraint firstItem="OFC-Xk-sa8" firstAttribute="centerX" secondItem="zQO-qZ-RSs" secondAttribute="centerX" id="qir-86-vsm"/>
-                        </constraints>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="ubi-eO-XpN" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-1324" y="0.0"/>
         </scene>
     </scenes>
     <resources>

--- a/LoveAndHiphop/LoveAndHiphop/MembershipQuizTableViewController.swift
+++ b/LoveAndHiphop/LoveAndHiphop/MembershipQuizTableViewController.swift
@@ -1,0 +1,169 @@
+//
+//  MembershipQuizTableViewController.swift
+//  LoveAndHiphop
+//
+//  Created by hollywoodno on 5/7/17.
+//  Copyright © 2017 Mogulla, Naveen. All rights reserved.
+//
+
+import UIKit
+import Parse
+
+class MembershipQuizTableViewController: UITableViewController {
+  
+  // MARK: Properties
+  @IBOutlet weak var question1Label: UILabel!
+  @IBOutlet weak var question2Label: UILabel!
+  @IBOutlet weak var trueFalseControl: UISegmentedControl!
+  @IBOutlet weak var multipleChoiceControl: UISegmentedControl!
+  
+  var factRightAnswer: String?
+  var multipleChoiceRightAnswer: String?
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    // Load quiz from parse
+    loadQuiz()
+  }
+  
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(true)
+    
+  }
+  
+  override func didReceiveMemoryWarning() {
+    super.didReceiveMemoryWarning()
+    // Dispose of any resources that can be recreated.
+  }
+  
+  // MARK: - Table view data source
+  
+  override func numberOfSections(in tableView: UITableView) -> Int {
+    // #warning Incomplete implementation, return the number of sections
+    return 5
+  }
+  
+  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    // #warning Incomplete implementation, return the number of rows
+    
+    if section == 2 || section == 3 {
+      return 2
+    }
+    
+    return 1
+  }
+  
+  
+  // MARK: Load Quiz
+  func loadQuiz() {
+    let query = PFQuery(className: "Quiz")
+    query.findObjectsInBackground { (quizzes: [PFObject]?, error: Error?) in
+      if error != nil {
+        print("Error retrieving quizes")
+      } else {
+        
+        for quiz in quizzes! {
+          let question = quiz["question"] as! Array<Any>
+          let questionType = quiz["type"] as! String
+          
+          if questionType == "fact" {
+            self.trueFalseControl.selectedSegmentIndex = -1
+            self.question1Label.text = question[0] as? String
+            self.trueFalseControl.setTitle("True", forSegmentAt: 0)
+            self.trueFalseControl.setTitle("False", forSegmentAt: 1)
+            self.factRightAnswer = question[1] as? String
+          }
+          
+          if questionType == "multiple" {
+            self.multipleChoiceControl.selectedSegmentIndex = -1
+            let answer1 = question[1] as? String
+            let answer2 = question[2] as? String
+            let answer3 = question[3] as? String
+            let answer4 = question[4] as? String
+            self.multipleChoiceRightAnswer = question[1] as? String
+            self.question2Label.text = question[0] as? String
+            self.multipleChoiceControl.setTitle(answer1, forSegmentAt: 0)
+            self.multipleChoiceControl.setTitle(answer2, forSegmentAt: 1)
+            self.multipleChoiceControl.setTitle(answer3, forSegmentAt: 2)
+            self.multipleChoiceControl.setTitle(answer4, forSegmentAt: 3)
+          }
+        }
+      }
+    }
+  }
+  
+  @IBAction func onSubmitQuiz(_ sender: Any) {
+    
+    //Grade users test
+    
+    let userFactAnswer = String(describing: trueFalseControl.selectedSegmentIndex)
+    let userMultipleChoiceAnswer = String(describing: multipleChoiceControl.selectedSegmentIndex)
+    
+    if userFactAnswer == factRightAnswer || userMultipleChoiceAnswer == multipleChoiceRightAnswer {
+      print("YOU PASSED HORRAY!!!!!!!!!!!!!!")
+      let fbVC = FBViewController(nibName: "FBViewController", bundle: nil)
+      show(fbVC, sender: self)
+    } else {
+      print("Oh fudge! No worries you can take the quiz as many times as you like.")
+      loadQuiz()
+    }
+    
+  }
+  
+  /*
+   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+   let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
+   
+   // Configure the cell...
+   
+   return cell
+   }
+   */
+  
+  /*
+   // Override to support conditional editing of the table view.
+   override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+   // Return false if you do not want the specified item to be editable.
+   return true
+   }
+   */
+  
+  /*
+   // Override to support editing the table view.
+   override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
+   if editingStyle == .delete {
+   // Delete the row from the data source
+   tableView.deleteRows(at: [indexPath], with: .fade)
+   } else if editingStyle == .insert {
+   // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+   }
+   }
+   */
+  
+  /*
+   // Override to support rearranging the table view.
+   override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
+   
+   }
+   */
+  
+  /*
+   // Override to support conditional rearranging of the table view.
+   override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+   // Return false if you do not want the item to be re-orderable.
+   return true
+   }
+   */
+  
+  /*
+   // MARK: - Navigation
+   
+   // In a storyboard-based application, you will often want to do a little preparation before navigation
+   override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+   // Get the new view controller using segue.destinationViewController.
+   // Pass the selected object to the new view controller.
+   }
+   */
+  
+}

--- a/LoveAndHiphop/LoveAndHiphop/Quiz.storyboard
+++ b/LoveAndHiphop/LoveAndHiphop/Quiz.storyboard
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1421" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="H5K-m2-V8F">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Membership Quiz Table View Controller-->
+        <scene sceneID="uLM-KY-zKD">
+            <objects>
+                <tableViewController storyboardIdentifier="MembershipQuizTableViewController" id="H5K-m2-V8F" customClass="MembershipQuizTableViewController" customModule="LoveAndHiphop" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="Dsu-0S-Npi">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <sections>
+                            <tableViewSection id="99g-xS-Z4q">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="64" id="ycL-mm-Wrf">
+                                        <rect key="frame" x="0.0" y="35" width="375" height="64"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ycL-mm-Wrf" id="U7P-QS-GLW">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="63"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="HipHop Quiz" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0v5-aF-Nqp">
+                                                    <rect key="frame" x="15" y="15" width="345" height="34"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="28"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="0v5-aF-Nqp" firstAttribute="leading" secondItem="U7P-QS-GLW" secondAttribute="leading" constant="15" id="MbA-Dv-JyP"/>
+                                                <constraint firstAttribute="trailing" secondItem="0v5-aF-Nqp" secondAttribute="trailing" constant="15" id="NO1-oW-lSa"/>
+                                                <constraint firstAttribute="bottom" secondItem="0v5-aF-Nqp" secondAttribute="bottom" constant="15" id="SNC-bb-M5b"/>
+                                                <constraint firstItem="0v5-aF-Nqp" firstAttribute="top" secondItem="U7P-QS-GLW" secondAttribute="top" constant="15" id="xNn-xE-Sn3"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="" id="9tz-7m-QUy">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="107" id="pGu-gW-tiC">
+                                        <rect key="frame" x="0.0" y="135" width="375" height="107"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="pGu-gW-tiC" id="di3-Bf-RLg">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="106"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A quick fun membership quiz to bring you up-to-date with HipHop." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="POT-EP-xtP">
+                                                    <rect key="frame" x="15" y="15" width="345" height="76.5"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="345" id="H8D-cR-UfK"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="21"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstItem="POT-EP-xtP" firstAttribute="leading" secondItem="di3-Bf-RLg" secondAttribute="leading" constant="15" id="3EV-jQ-bFV"/>
+                                                <constraint firstAttribute="bottom" secondItem="POT-EP-xtP" secondAttribute="bottom" constant="15" id="AUO-Oc-U4g"/>
+                                                <constraint firstAttribute="trailing" secondItem="POT-EP-xtP" secondAttribute="trailing" constant="15" id="J8H-NP-CJO"/>
+                                                <constraint firstItem="POT-EP-xtP" firstAttribute="top" secondItem="di3-Bf-RLg" secondAttribute="top" constant="15" id="a5t-Lc-XEi"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="Facts" id="SBe-IN-Gfi">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="88" id="NCs-ff-QXi">
+                                        <rect key="frame" x="0.0" y="299" width="375" height="88"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="NCs-ff-QXi" id="ZqU-UK-dcr">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="87"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Snoop Dog is known for founding Beats audio." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIG-Tk-HSS">
+                                                    <rect key="frame" x="15" y="15" width="345" height="57.5"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="thin" pointSize="14"/>
+                                                    <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="SIG-Tk-HSS" secondAttribute="bottom" constant="15" id="QS1-uL-k5I"/>
+                                                <constraint firstAttribute="trailing" secondItem="SIG-Tk-HSS" secondAttribute="trailing" constant="15" id="cuv-f3-jd1"/>
+                                                <constraint firstItem="SIG-Tk-HSS" firstAttribute="top" secondItem="ZqU-UK-dcr" secondAttribute="top" constant="15" id="qtP-nA-YlP"/>
+                                                <constraint firstItem="SIG-Tk-HSS" firstAttribute="leading" secondItem="ZqU-UK-dcr" secondAttribute="leading" constant="15" id="txl-W1-RXP"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="37" id="6Vh-vh-hTP">
+                                        <rect key="frame" x="0.0" y="387" width="375" height="37"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="6Vh-vh-hTP" id="IIv-cc-WWN">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="36"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <segmentedControl opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" translatesAutoresizingMaskIntoConstraints="NO" id="BVV-cc-9wK">
+                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="37.5"/>
+                                                    <segments>
+                                                        <segment title="True"/>
+                                                        <segment title="False"/>
+                                                    </segments>
+                                                </segmentedControl>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstItem="BVV-cc-9wK" firstAttribute="leading" secondItem="IIv-cc-WWN" secondAttribute="leading" id="Gu3-hX-xlb"/>
+                                                <constraint firstAttribute="trailing" secondItem="BVV-cc-9wK" secondAttribute="trailing" id="cnv-pD-gPS"/>
+                                                <constraint firstAttribute="bottom" secondItem="BVV-cc-9wK" secondAttribute="bottom" id="dZT-Mp-6eB"/>
+                                                <constraint firstItem="BVV-cc-9wK" firstAttribute="top" secondItem="IIv-cc-WWN" secondAttribute="top" id="mFW-eQ-iTZ"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="MUSIC TRENDS" footerTitle="" id="zI7-gy-Ejx">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="kjR-0t-Oa7">
+                                        <rect key="frame" x="0.0" y="488" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="kjR-0t-Oa7" id="dul-6t-raI">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Which rap artist popularized autotune in hiphop?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YRU-hi-Lrj">
+                                                    <rect key="frame" x="15" y="15" width="345" height="14"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="345" id="2tB-6h-inG"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" weight="thin" pointSize="14"/>
+                                                    <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="YRU-hi-Lrj" secondAttribute="bottom" constant="15" id="JSK-a8-OZv"/>
+                                                <constraint firstItem="YRU-hi-Lrj" firstAttribute="top" secondItem="dul-6t-raI" secondAttribute="top" constant="15" id="Knr-mz-1VD"/>
+                                                <constraint firstAttribute="trailing" secondItem="YRU-hi-Lrj" secondAttribute="trailing" constant="15" id="Z2k-yD-BuD"/>
+                                                <constraint firstItem="YRU-hi-Lrj" firstAttribute="leading" secondItem="dul-6t-raI" secondAttribute="leading" constant="15" id="uBJ-g1-er7"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="42" id="8oO-jz-M9k">
+                                        <rect key="frame" x="0.0" y="519" width="375" height="42"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="8oO-jz-M9k" id="Rxw-gG-Y32">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="41"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" translatesAutoresizingMaskIntoConstraints="NO" id="7k1-RI-M5X">
+                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="42.5"/>
+                                                    <segments>
+                                                        <segment title="Drake"/>
+                                                        <segment title="Lady Gaga"/>
+                                                        <segment title="TPain"/>
+                                                        <segment title="Lady Gaga"/>
+                                                    </segments>
+                                                </segmentedControl>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="7k1-RI-M5X" firstAttribute="leading" secondItem="Rxw-gG-Y32" secondAttribute="leading" id="LLL-kq-Wdf"/>
+                                                <constraint firstItem="7k1-RI-M5X" firstAttribute="top" secondItem="Rxw-gG-Y32" secondAttribute="top" id="bRN-vJ-3Mn"/>
+                                                <constraint firstAttribute="trailing" secondItem="7k1-RI-M5X" secondAttribute="trailing" id="f6L-Le-tqZ"/>
+                                                <constraint firstAttribute="bottom" secondItem="7k1-RI-M5X" secondAttribute="bottom" id="rAH-Cn-Ohf"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection id="KNm-Wb-mFh">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="cdS-yu-yHZ">
+                                        <rect key="frame" x="0.0" y="610" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="cdS-yu-yHZ" id="cg4-Cz-7h3">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jDN-vL-uuX">
+                                                    <rect key="frame" x="123" y="8" width="116" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <color key="backgroundColor" red="0.16558837779999999" green="0.25657037240000002" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                    <state key="normal" title="Submit">
+                                                        <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="onSubmitQuiz:" destination="H5K-m2-V8F" eventType="touchUpInside" id="8r8-Qk-WtP"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="H5K-m2-V8F" id="Php-we-AlA"/>
+                            <outlet property="delegate" destination="H5K-m2-V8F" id="bQh-FR-1wd"/>
+                        </connections>
+                    </tableView>
+                    <connections>
+                        <outlet property="multipleChoiceControl" destination="7k1-RI-M5X" id="NXn-Fo-5ic"/>
+                        <outlet property="question1Label" destination="SIG-Tk-HSS" id="PWx-3N-Z0e"/>
+                        <outlet property="question2Label" destination="YRU-hi-Lrj" id="ris-ev-Os3"/>
+                        <outlet property="trueFalseControl" destination="BVV-cc-9wK" id="pxG-UF-4V1"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="odo-f8-PaB" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer id="8DV-Bm-4WZ"/>
+            </objects>
+            <point key="canvasLocation" x="-2082.4000000000001" y="707.49625187406298"/>
+        </scene>
+    </scenes>
+</document>

--- a/LoveAndHiphop/LoveAndHiphop/SubmitQuizViewController.swift
+++ b/LoveAndHiphop/LoveAndHiphop/SubmitQuizViewController.swift
@@ -36,6 +36,10 @@ class SubmitQuizViewController: UIViewController {
     } else {
       // Send to beginning of quiz
       print("Oh fudge, you didn't pass this time!")
+      
+      // Currently, if user fails quiz we just reissue same quiz
+      let membershipQuizVC = storyboard?.instantiateViewController(withIdentifier: "MembershipQuizTableViewController") as! MembershipQuizTableViewController
+      show(membershipQuizVC, sender: self)
     }
   }
   


### PR DESCRIPTION
This updates the quiz to be a tableview with just 2 questions. 

The test is issue on launching the app. If users passes they are sent to login with Facebook, but if they fail the quiz is reloaded.

Not implemented: This quiz is issued to all users even if they have previously passed the quiz. This will be fixed in a future PR.

Fixes issue #4 